### PR TITLE
Modifier la valeur php `memory_limit` dans la configuration du buildpack

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,9 @@
+{
+  "extra": {
+    "paas": {
+      "php-config": [
+        "memory_limit": "2048M"
+      ],
+    }
+  }
+}


### PR DESCRIPTION
Selon [la doc de Scalingo](https://doc.scalingo.com/languages/php/start#buildpack-custom-configuration) on peut modifier la configuration de PHP grâce au buildpack.

Ce dont je ne suis pas sûr, c'est les relations entre buildpacks, s'il est possible de configurer les valeurs de buildpacks avec le `composer.json` et d'hériter (?) le `.buildpacks`.

Et puis je ne suis toujours pas à l'aise pour le déploiement, je ne préfère pas le faire seul derrière mon écran !