### PR TITLE
Passer `MATOMO_AUTO_ARCHIVING_MEMORY_LIMIT` aux sous-commandes d'archivage

### DIFF
--- a/bin/auto-archiving-reports.sh
+++ b/bin/auto-archiving-reports.sh
@@ -14,7 +14,7 @@ else
   while true; do
     echo "Archiving reports... "
     if [[ -n "$MATOMO_AUTO_ARCHIVING_MEMORY_LIMIT" ]]; then
-      php -d memory_limit="${MATOMO_AUTO_ARCHIVING_MEMORY_LIMIT}M" console core:archive
+      php -d memory_limit="${MATOMO_AUTO_ARCHIVING_MEMORY_LIMIT}M" console core:archive --php-cli-options="-d memory_limit=${MATOMO_AUTO_ARCHIVING_MEMORY_LIMIT}M"
     else
       php console core:archive
     fi


### PR DESCRIPTION
D'après la doc (`./console core:archive --help`) :

` --php-cli-options  Forwards the PHP configuration options to the PHP CLI command. For example "-d memory_limit=8G". Note:  These options are only applied if the archiver actually uses CLI and not HTTP. (default: "")`

Et en effet, quand on lance manuellement : 
`php -d memory_limit=2G console core:archive --force-idsites 117 --php-cli-options="-d memory_limit=2G" --skip-segments-today -vv`

On voit dans le debug :
```
DEBUG [2025-02-19 13:11:34] 303  Running command: /app/vendor/php/bin/php -q -d memory_limit=2G /app/console climulti:request -q --matomo-domain='' --superuser 'module=API&method=CoreAdminHome.archiveReports&idSite=117&period=day&date=2025-01-21&format=json&segment=dimension1%3D%3DEMPLOYER%3Bdimension3%3D%3DGEIQ&plugin=Funnels&trigger=archivephp&skipArchiveSegmentToday=1&pluginOnly=1&requestedReport=115&pid=0cceac3668&runid=303'  > /app/tmp/climulti/0cceac36443802e8725d491f31b255a0608f263d5c03d3c375d600ae654a2ebe21fc041abc48a7322f81a9a2ae8d9f1facc68.output 2>&1 &
```

J'ai maintenant des doutes sur l'origine du problème de mémoire PHP, je ne sais pas quel processus est limité.

Sans doute que #1 règlerait tous les problèmes d'un coup, en augmentant la valeur par défaut.
